### PR TITLE
add stripslashes to template value!

### DIFF
--- a/admin/class-wcemails-admin.php
+++ b/admin/class-wcemails-admin.php
@@ -113,6 +113,7 @@ if ( ! class_exists( 'WCEmails_Admin' ) ) {
 					foreach ( $wcemails_email_details as $key => $details ) {
 						if ( $_REQUEST['wcemails_edit'] == $key ) {
 							$wcemails_detail = $details;
+							$wcemails_detail['template'] = stripslashes($wcemails_detail['template']);
 						}
 					}
 				}
@@ -443,7 +444,7 @@ if ( ! class_exists( 'WCEmails_Admin' ) ) {
 						$from_status   = isset( $details['from_status'] ) ? $details['from_status'] : array();
 						$to_status     = isset( $details['to_status'] ) ? $details['to_status'] : array();
 						$send_customer = isset( $details['send_customer'] ) ? $details['send_customer'] : array();
-						$template    = html_entity_decode( isset( $details['template'] ) ? $details['template'] : '' );
+						$template    = stripslashes(html_entity_decode( isset( $details['template'] ) ? $details['template'] : '' ));
 
 						$wcemails_instance = new WCEmails_Instance( $id, $title, $description, $subject, $recipients, $heading, $from_status, $to_status, $send_customer, $template );
 


### PR DESCRIPTION
for saving (top edit) - otherwise you end up with more slashes on quotes etc. on every save
and sending (bottom edit) - otherwise the sent email contains the slashes and breaks the HTML display